### PR TITLE
fix: prevent video refresh when toggling mic mute/unmute

### DIFF
--- a/src/components/VideoRoom.tsx
+++ b/src/components/VideoRoom.tsx
@@ -342,7 +342,8 @@ export function VideoRoom({ socket, roomId, userName, onLeaveRoom }: VideoRoomPr
       // Clean up connections
       cleanupConnections();
     };
-  }, [socket, roomId, userName, isVideoEnabled, isAudioEnabled]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- isVideoEnabled/isAudioEnabled intentionally excluded; toggling is handled by webrtc.ts on the existing stream, not by re-running setupMedia
+  }, [socket, roomId, userName]);
   
   // Track if we've already announced our media readiness to prevent loops
   const [hasAnnouncedReady, setHasAnnouncedReady] = useState(false);


### PR DESCRIPTION
## Summary
- Remove `isVideoEnabled` and `isAudioEnabled` from the main `useEffect` dependency array in `VideoRoom.tsx`
- Toggling mute/unmute was triggering a full `setupMedia` re-run (new `getUserMedia` stream + WebRTC re-init), blacking out the video
- The `toggleAudio()`/`toggleVideo()` functions already enable/disable tracks on the existing stream directly — no need to recreate anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video and audio toggle responsiveness by preventing unnecessary media re-initialization when toggling these settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->